### PR TITLE
refactor: build-release をビルド・リリースのみに整理する

### DIFF
--- a/.github/workflows/build-release.yml
+++ b/.github/workflows/build-release.yml
@@ -1,4 +1,4 @@
-name: Build and Release (with DB)
+name: Build and Release
 
 on:
   push:
@@ -8,8 +8,6 @@ on:
 jobs:
   build:
     runs-on: ubuntu-latest
-    env:
-      DATA_URL: "https://www.post.japanpost.jp/service/search/zipcode/download/utf/zip/utf_ken_all.zip"
     permissions:
       contents: write
 
@@ -25,60 +23,23 @@ jobs:
       - name: Install build deps
         run: |
           python -m pip install --upgrade pip
-          pip install build
+          python -m pip install build
 
       - name: Install jq
         run: |
           sudo apt-get update
           sudo apt-get install -y jq
 
-      - name: Download utf_ken_all.zip
-        run: |
-          set -euo pipefail
-          echo "Downloading utf_ken_all.zip"
-          curl -sSL -o utf_ken_all.zip "$DATA_URL"
-          unzip -o utf_ken_all.zip
-
-      - name: Compute checksum
-        run: |
-          set -euo pipefail
-          echo "Computing checksum"
-          sha256sum utf_ken_all.zip | awk '{print $1}' > utf_ken_all.sha256
-
-      - name: Check previous checksum on latest release
-        env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-          GITHUB_REPOSITORY: ${{ github.repository }}
-        run: |
-          set -euo pipefail
-          echo "Checking latest release for previous checksum"
-          latest=$(curl -s -H "Authorization: token ${GITHUB_TOKEN}" "https://api.github.com/repos/${GITHUB_REPOSITORY}/releases/latest" || true)
-          prev_asset_url=$(echo "$latest" | jq -r '.assets[]? | select(.name=="utf_ken_all.sha256") | .url' || true)
-
-          if [ -n "$prev_asset_url" ]; then
-            curl -sL -H "Authorization: token ${GITHUB_TOKEN}" -H "Accept: application/octet-stream" "$prev_asset_url" -o prev_utf_ken_all.sha256 || true
-            if [ -f prev_utf_ken_all.sha256 ] && cmp -s prev_utf_ken_all.sha256 utf_ken_all.sha256; then
-              echo "No change in data; exiting."
-              exit 0
-            fi
-          fi
-
-      - name: Generate DB
-        run: |
-          python3 scripts/generate_db.py utf_ken_all.csv src/zip2addr/zip2addr.db
-
-      - name: Prepare version from data_version
+      - name: Prepare version
         id: prepare_version
         run: |
           set -euo pipefail
-          # try to read DATA_DATE from committed data_version.py (created by data-check PR)
           if [ -f src/zip2addr/data_version.py ]; then
             DATA_DATE=$(python -c "import importlib.util,sys;spec=importlib.util.spec_from_file_location('dv','src/zip2addr/data_version.py');dv=importlib.util.module_from_spec(spec);spec.loader.exec_module(dv);print(getattr(dv,'DATA_DATE',''))")
           else
             DATA_DATE=$(date +%Y%m%d)
           fi
 
-          # extract MAJOR.MINOR from existing pyproject.toml
           if grep -q '^version' pyproject.toml; then
             MAJOR=$(grep '^version' pyproject.toml | sed -E 's/version\s*=\s*"([0-9]+)\.([0-9]+)\..*"/\1/' || echo 0)
             MINOR=$(grep '^version' pyproject.toml | sed -E 's/version\s*=\s*"([0-9]+)\.([0-9]+)\..*"/\2/' || echo 1)
@@ -106,7 +67,6 @@ jobs:
           GITHUB_REPOSITORY: ${{ github.repository }}
         run: |
           set -euo pipefail
-          # Use DATA_DATE from previous step outputs, fallback to today
           DATA_DATE="${{ steps.prepare_version.outputs.data_date }}"
           if [ -z "${DATA_DATE}" ]; then
             DATA_DATE=$(date +%Y%m%d)
@@ -142,6 +102,3 @@ jobs:
             echo "Uploading $f"
             curl -sS --fail -X POST -H "Authorization: token ${GITHUB_TOKEN}" -H "Content-Type: application/octet-stream" --data-binary @"$f" "${UPLOAD_URL}?name=$(basename $f)"
           done
-
-          echo "Uploading checksum"
-          curl -sS --fail -X POST -H "Authorization: token ${GITHUB_TOKEN}" -H "Content-Type: text/plain" --data-binary @utf_ken_all.sha256 "${UPLOAD_URL}?name=utf_ken_all.sha256"

--- a/.github/workflows/data-check.yml
+++ b/.github/workflows/data-check.yml
@@ -53,43 +53,48 @@ jobs:
             echo "No change in data; exiting"
           fi
 
-      - name: Update DB and create PR
+      - name: Generate DB
+        id: generate_db
         if: ${{ steps.check_change.outputs.no_change != 'true' }}
-        env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
           set -euo pipefail
-          echo "Data changed — updating DB and creating PR"
-
-          # Generate DB
+          echo "Data changed — regenerating DB"
           unzip -o utf_ken_all.zip
           python3 scripts/generate_db.py utf_ken_all.csv src/zip2addr/zip2addr.db
 
-          # Record data date
           DATA_DATE=$(date +%Y%m%d)
           cat > src/zip2addr/data_version.py <<PYEOF
           DATA_DATE = "${DATA_DATE}"
           PYEOF
 
-          # Configure git
           git config user.name "github-actions[bot]"
           git config user.email "github-actions[bot]@users.noreply.github.com"
 
-          # Commit and push to develop (skip if no actual changes)
           git add src/zip2addr/zip2addr.db src/zip2addr/data_version.py
           if git diff --cached --quiet; then
             echo "No actual file changes after regeneration; skipping commit"
-            exit 0
+            echo "committed=false" >> $GITHUB_OUTPUT
+          else
+            git commit -m "data: 郵便番号データを ${DATA_DATE} 版に更新"
+            git push origin develop
+            echo "committed=true" >> $GITHUB_OUTPUT
+            echo "data_date=${DATA_DATE}" >> $GITHUB_OUTPUT
           fi
-          git commit -m "data: 郵便番号データを ${DATA_DATE} 版に更新"
-          git push origin develop
 
-          # Create PR develop → master (skip if one already exists)
+      - name: Create PR
+        if: ${{ steps.generate_db.outputs.committed == 'true' }}
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          set -euo pipefail
+          DATA_DATE="${{ steps.generate_db.outputs.data_date }}"
+
           EXISTING_PR=$(gh pr list --base master --head develop --state open --json number --jq '.[0].number')
           if [ -n "$EXISTING_PR" ]; then
             echo "PR #${EXISTING_PR} is already open; skipping creation"
             exit 0
           fi
+
           gh pr create \
             --base master \
             --head develop \


### PR DESCRIPTION
## Summary

build-release ワークフローからデータダウンロード・DB 生成・チェックサム比較を削除し、ビルドとリリース作成のみに整理。

## 背景

現在の運用フロー:
1. `data-check` がデータをダウンロードし DB を生成して develop にコミット
2. develop → master の PR を作成
3. master マージで `build-release` が実行

DB は master に既に含まれているため、build-release で再度ダウンロード・生成する必要がない。

## 削除した処理

- `DATA_URL` 環境変数
- `Download utf_ken_all.zip` ステップ
- `Compute checksum` ステップ
- `Check previous checksum on latest release` ステップ
- `Generate DB` ステップ
- チェックサムのアップロード

## 残した処理

- バージョン決定（`data_version.py` / `pyproject.toml` から）
- wheel / sdist のビルド
- GitHub Release の作成・アーティファクトアップロード