### PR TITLE
[T16] カスタムドメイン設定に合わせてドキュメントを更新

### DIFF
--- a/docs/api.md
+++ b/docs/api.md
@@ -2,7 +2,7 @@
 
 ## ベース URL
 
-Render デプロイ後のベース URL は `https://<サービス名>.onrender.com` となる。
+`https://zip2addr-jp.nemoto.click`
 
 ## エンドポイント一覧
 

--- a/docs/infra.md
+++ b/docs/infra.md
@@ -3,7 +3,8 @@
 ## 構成図
 
 ```
-[クライアント] → [Cloudflare DNS] → [Render] → [FastAPI + uvicorn] → [SQLite DB (同梱)]
+[クライアント] --名前解決--> [Cloudflare DNS]
+[クライアント] --HTTPS--> [Render] --> [FastAPI + uvicorn] --> [SQLite DB (同梱)]
 ```
 
 ## 環境一覧

--- a/docs/infra.md
+++ b/docs/infra.md
@@ -3,14 +3,14 @@
 ## 構成図
 
 ```
-[クライアント] → [Render (Free)] → [FastAPI + uvicorn] → [SQLite DB (同梱)]
+[クライアント] → [Cloudflare DNS] → [Render] → [FastAPI + uvicorn] → [SQLite DB (同梱)]
 ```
 
 ## 環境一覧
 
 | 環境 | URL | 備考 |
 |------|-----|------|
-| 本番 | `https://<サービス名>.onrender.com` | Render Free プラン |
+| 本番 | `https://zip2addr-jp.nemoto.click` | Render Free プラン、カスタムドメイン（Cloudflare DNS） |
 
 ## Render Free プランの制限
 
@@ -35,4 +35,20 @@
 
 ### 自動デプロイ
 
-Render は接続した GitHub リポジトリの master ブランチへのプッシュを検出し、自動でデプロイを実行する。
+Render は接続した GitHub リポジトリの develop ブランチへのプッシュを検出し、自動でデプロイを実行する。
+
+## カスタムドメイン設定
+
+### Render 側
+
+1. Dashboard → zip2addr-jp-api → Settings → Custom Domains
+2. `zip2addr-jp.nemoto.click` を追加
+3. 表示される CNAME ターゲット（`zip2addr-jp-api.onrender.com`）をメモ
+4. DNS 設定後に Verify をクリック
+
+### Cloudflare 側
+
+1. DNS → レコードの追加
+2. タイプ: `CNAME`、名前: `zip2addr-jp`、ターゲット: `zip2addr-jp-api.onrender.com`
+3. プロキシステータス: **DNS only**（Render の SSL と競合するため）
+4. SSL 証明書は Render 側で自動発行される

--- a/docs/infra.md
+++ b/docs/infra.md
@@ -51,5 +51,5 @@ Render は接続した GitHub リポジトリの develop ブランチへのプ�
 
 1. DNS → レコードの追加
 2. タイプ: `CNAME`、名前: `zip2addr-jp`、ターゲット: `zip2addr-jp-api.onrender.com`
-3. プロキシステータス: **DNS only**（Render の SSL と競合するため）
+3. プロキシステータス: **DNS only**（現時点では Render の SSL 証明書との互換性を優先し DNS only で運用）
 4. SSL 証明書は Render 側で自動発行される


### PR DESCRIPTION
## Summary
- `docs/api.md`: ベース URL を `https://zip2addr-jp.nemoto.click` に更新
- `docs/infra.md`: 構成図に Cloudflare 追加、環境 URL 更新、カスタムドメイン設定手順追記、デプロイブランチを develop に修正

Closes #21

## Test plan
- [ ] `https://zip2addr-jp.nemoto.click/api/v1/health` にアクセスできることを確認済み
- [ ] ドキュメントの記載内容が実環境と一致していることを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)